### PR TITLE
[CLEANUP] - Blackduck fix mount

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,6 @@ runs:
          echo "ls -la /github/workspace $(ls -la /github/workspace)"
          java -jar /synopsys-detect.jar \
           --detect.source.path=/workdir \
-          # --detect.output.path=/workdir \
           --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \
           --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
           --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \

--- a/action.yaml
+++ b/action.yaml
@@ -21,9 +21,9 @@ runs:
       uses: addnab/docker-run-action@v3
       with:
         image: blackducksoftware/detect:8
-        options:  --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
+        options:  --entrypoint "/bin/bash"
         run: |
-         echo "ls -la /workdir $(/workdir)"
+         # echo "ls -la /workdir $(/workdir)"
          echo "ls -la /github/workspace $(/github/workspace)"
          java -jar /synopsys-detect.jar \
           --detect.source.path=/github/workspace \

--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ runs:
         options:  --entrypoint "/bin/bash"
         run: |
          # echo "ls -la /workdir $(/workdir)"
-         echo "ls -la /github/workspace $(/github/workspace)"
+         echo "ls -la /github/workspace $(ls -la /github/workspace)"
          java -jar /synopsys-detect.jar \
           --detect.source.path=/github/workspace \
           --detect.output.path=/github/workspace \

--- a/action.yaml
+++ b/action.yaml
@@ -21,11 +21,11 @@ runs:
       uses: addnab/docker-run-action@v3
       with:
         image: blackducksoftware/detect:8
-        options:  --entrypoint "/bin/bash" 
+        options:  --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
         run: |
          java -jar /synopsys-detect.jar \
-          --detect.source.path=${{ github.workspace }} \
-          --detect.output.path=${{ github.workspace }} \
+          --detect.source.path=/workdir \
+          --detect.output.path=/workdir \
           --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \
           --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
           --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \

--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ runs:
         options:  --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
         run: |
          echo "ls -la /workdir $(ls -la /workdir)"
-         echo "ls -la /github/workspace $(ls -la /github/workspace)"
+         echo "ls -la /workdir/frontend $(ls -la /workdir/frontend)"
          java -jar /synopsys-detect.jar \
           --detect.source.path=/workdir \
           --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \

--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ runs:
          echo "ls -la /github/workspace $(ls -la /github/workspace)"
          java -jar /synopsys-detect.jar \
           --detect.source.path=/workdir \
-          --detect.output.path=/workdir \
+          # --detect.output.path=/workdir \
           --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \
           --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
           --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \

--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,7 @@ runs:
           --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
           --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \
           --blackduck.url="${{ env.BlackDuck_Url }}" \
-          --detect.blackduck.signature.scanner.snippet.matching="NONE" ${{ env.ADDITIONAL_ARG }}
+          --detect.blackduck.signature.scanner.snippet.matching="NONE" ${{ env.ADDITIONAL_ARGS }}
           
       
     - name: OWASP Scan

--- a/action.yaml
+++ b/action.yaml
@@ -23,8 +23,6 @@ runs:
         image: blackducksoftware/detect:8
         options:  --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
         run: |
-         echo "ls -la /workdir $(ls -la /workdir)"
-         echo "ls -la /workdir/frontend $(ls -la /workdir/frontend)"
          java -jar /synopsys-detect.jar \
           --detect.source.path=/workdir \
           --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \

--- a/action.yaml
+++ b/action.yaml
@@ -21,13 +21,13 @@ runs:
       uses: addnab/docker-run-action@v3
       with:
         image: blackducksoftware/detect:8
-        options:  --entrypoint "/bin/bash"
+        options:  --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
         run: |
-         # echo "ls -la /workdir $(/workdir)"
-         echo "ls -la /github/workspace $(ls -la /github/workspace)"
+         echo "ls -la /workdir $(ls -la /workdir)"
+         # echo "ls -la /github/workspace $(ls -la /github/workspace)"
          java -jar /synopsys-detect.jar \
-          --detect.source.path=/github/workspace \
-          --detect.output.path=/github/workspace \
+          --detect.source.path=/workdir \
+          --detect.output.path=/workdir \
           --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \
           --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
           --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,8 @@ runs:
         image: blackducksoftware/detect:8
         options:  --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
         run: |
+         echo "ls -la /workdir $(/workdir)"
+         echo "ls -la /github/workspace $(/github/workspace)"
          java -jar /synopsys-detect.jar \
           --detect.source.path=/workdir \
           --detect.output.path=/workdir \

--- a/action.yaml
+++ b/action.yaml
@@ -26,8 +26,8 @@ runs:
          echo "ls -la /workdir $(/workdir)"
          echo "ls -la /github/workspace $(/github/workspace)"
          java -jar /synopsys-detect.jar \
-          --detect.source.path=/workdir \
-          --detect.output.path=/workdir \
+          --detect.source.path=/github/workspace \
+          --detect.output.path=/github/workspace \
           --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \
           --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
           --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \

--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,8 @@ runs:
           --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
           --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \
           --blackduck.url="${{ env.BlackDuck_Url }}" \
-          --detect.blackduck.signature.scanner.snippet.matching="NONE" 
+          --detect.blackduck.signature.scanner.snippet.matching="NONE" ${{ env.ADDITIONAL_ARG }}
+          
       
     - name: OWASP Scan
       if: ${{ env.owasp_Project }}

--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ runs:
       uses: addnab/docker-run-action@v3
       with:
         image: blackducksoftware/detect:8
-        options:  --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
+        options:  --entrypoint "/bin/bash" -v $GITHUB_WORKSPACE:/workdir
         run: |
          echo "ls -la /workdir $(ls -la /workdir)"
          # echo "ls -la /github/workspace $(ls -la /github/workspace)"

--- a/action.yaml
+++ b/action.yaml
@@ -21,10 +21,10 @@ runs:
       uses: addnab/docker-run-action@v3
       with:
         image: blackducksoftware/detect:8
-        options:  --entrypoint "/bin/bash" -v $GITHUB_WORKSPACE:/workdir
+        options:  --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
         run: |
          echo "ls -la /workdir $(ls -la /workdir)"
-         # echo "ls -la /github/workspace $(ls -la /github/workspace)"
+         echo "ls -la /github/workspace $(ls -la /github/workspace)"
          java -jar /synopsys-detect.jar \
           --detect.source.path=/workdir \
           --detect.output.path=/workdir \


### PR DESCRIPTION
Fix bug according to https://hitachivantara-eng.slack.com/archives/C03LV5245A9/p1675186564721359.
The mount was incorrect, fixed it by specifying the mount in the action: 
options: --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir