### PR TITLE
Make detect.source.path configurable

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -64,7 +64,7 @@ runs:
         options: --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
         run: |
           java -jar /synopsys-detect.jar \
-           --detect.source.path=/workdir \
+           --detect.source.path=${{ env.BlackDuck_Source_Path || '/workdir' }} \
            --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \
            --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
            --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \


### PR DESCRIPTION
We need to run Blackduck scans in a specific directory. Since the --detect.source.path is hardcoded the scan does not analyze the folder intended even though we increase the scan depth.

Trying to override the `--detect.source.path` property does not work as can be seen in this run:

https://github.com/lumada-design/hv-app-shell/actions/runs/5244526216/jobs/9470674150?pr=247

