### PR TITLE
[YKN-445] : BlackDuck step not showing in GH job summary and Slack Notification when trigger manually.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -230,7 +230,8 @@ runs:
         else
             echo "| Sonar Scan | :${{ steps.all_icons.outputs.sonar_scan }}: |" >> $GITHUB_STEP_SUMMARY
         fi
-
+             
+        echo "Blackduck icon ${{ steps.all_icons.outputs.blackduck_scan }}"
         if [ "${{ github.event_name }}" == "push" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
           if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
             blackduck_result="${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components"

--- a/action.yaml
+++ b/action.yaml
@@ -270,7 +270,11 @@ runs:
               details="<${{ github.event.head_commit.url }}| Details>"
             fi
             commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
-
+            # Check if the commit message is empty.
+            if [ -z "$commit" ]; then
+              # If it's empty, set "github.event_name" as a message.
+              commit="Workflow was triggered by ${{ github.event_name }} event."
+            fi
             blackduck_result="Blackduck"
             if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
               blackduck_result="<${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components|${blackduck_result}>"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "$commit" | tr -d '\n' | cut -c1-27) ...''"          
+              commit="$(echo "''$commit" | tr -d '\n' | cut -c1-27) ...''"          
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -231,7 +231,7 @@ runs:
             echo "| Sonar Scan | :${{ steps.all_icons.outputs.sonar_scan }}: |" >> $GITHUB_STEP_SUMMARY
         fi
              
-        echo "Blackduck icon ${{ steps.all_icons.outputs.blackduck_scan }}"
+        echo "Blackduck icon '${{ steps.all_icons.outputs.blackduck_scan }}'"
         if [ "${{ github.event_name }}" == "push" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
           if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
             blackduck_result="${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components"

--- a/action.yaml
+++ b/action.yaml
@@ -273,7 +273,7 @@ runs:
             # Check if the commit message is empty.
             if [ -z "$commit" ]; then
               # If it's empty, set a default message based on the triggering event.
-              commit=""Triggered by ${{ github.event_name }}.""
+              commit="\"Workflow was triggered by ${{ github.event_name }} event.\""
             else
               commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
             fi

--- a/action.yaml
+++ b/action.yaml
@@ -274,10 +274,10 @@ runs:
             if [ -z "$commit" ]; then
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
-            else           
-              commit=$(echo "$commit" | tr -d '\n')
-              commit="$(echo "''$commit" | cut -c1-27) ...''" 
+            else
+              commit="$(echo "$commit" | tr -d '\n' | cut -c1-27) ...''"          
             fi
+            
             blackduck_result="Blackduck"
             if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
               blackduck_result="<${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components|${blackduck_result}>"

--- a/action.yaml
+++ b/action.yaml
@@ -263,7 +263,7 @@ runs:
         blackduck_result=""
         blackduck_message=""
         branch="${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "push" ]; then
+        if [ "${{ github.event_name }}" == "push" ]  || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             details="<${{ github.event.head_commit.url}}| Details>"
             commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
 

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr '\n' '' | cut -c1-27) ...''"         
+              commit="$(echo "''$commit" | tr '\n' ' ' | cut -c1-27) ...''"         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr '\n' '' | cut -c1-27)...''"         
+              commit="$(echo "''$commit" | tr '\n' '\t' | cut -c1-27)...''"         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr -d '\n' | cut -c1-27) ...''"      
+              commit="$(echo "''$commit" | tr '\n' ' ' | sed 's/ \+/ /g' | cut -c1-27) ...''"      
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -274,8 +274,9 @@ runs:
             if [ -z "$commit" ]; then
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
-            else
-              commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
+            else           
+              commit=$(echo "$commit" | tr -d '\n')
+              commit="$(echo "''$commit}" | cut -c1-27) ...''" 
             fi
             blackduck_result="Blackduck"
             if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then

--- a/action.yaml
+++ b/action.yaml
@@ -276,6 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
+              commit=$(echo "$commit" | tr -s ' ' | sed 's/^ *//' | sed 's/ *$//')
               commit="$(echo "''$commit" | tr -d '\n' | cut -c1-27) ...''"          
             fi
 

--- a/action.yaml
+++ b/action.yaml
@@ -272,7 +272,6 @@ runs:
             commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
             # Check if the commit message is empty.
             if [ -z "$commit" ]; then
-              # If it's empty, set "github.event_name" as a message.
               commit="Workflow was triggered by ${{ github.event_name }} event."
             fi
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr -s '\n' '\t' | cut -c1-27) ...''"         
+              commit="$(echo "''$commit" | tr '\n' ' ' | cut -c1-27) ...''"         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -269,10 +269,13 @@ runs:
             else
               details="<${{ github.event.head_commit.url }}| Details>"
             fi
-            commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
+            commit="${{ github.event.head_commit.message }}"
             # Check if the commit message is empty.
             if [ -z "$commit" ]; then
+              # If it's empty, set a default message based on the triggering event.
               commit="Workflow was triggered by ${{ github.event_name }} event."
+            else
+              commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
             fi
             blackduck_result="Blackduck"
             if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr '\n' ' ' | sed 's/ \+/ /g' | cut -c1-27) ...''"      
+              commit="$(echo "''$commit" | tr '\n' ' ' | sed 's/ \+/ /g' | cut -c1-27)...''"      
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -232,7 +232,7 @@ runs:
         fi
              
         echo "Blackduck icon '${{ steps.all_icons.outputs.blackduck_scan }}'"
-        if [ "${{ github.event_name }}" == "push" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+        if [ "${{ github.event_name }}" == "push" ]; then
           if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
             blackduck_result="${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components"
             echo "| [Blackduck Scan]($blackduck_result) | :${{ steps.all_icons.outputs.blackduck_scan }}: |" >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr '\n' ' ' | cut -c1-27) ...''"         
+              commit="$(echo "''$commit" | tr '\n' '' | cut -c1-27)...''"         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -264,7 +264,11 @@ runs:
         blackduck_message=""
         branch="${GITHUB_REF#refs/heads/}"
         if [ "${{ github.event_name }}" == "push" ]  || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            details="<${{ github.event.head_commit.url}}| Details>"
+            if [ -z "${{ github.event.head_commit.url }}" ]; then
+              details="Details"
+            else
+              details="<${{ github.event.head_commit.url }}| Details>"
+            fi
             commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr -d '\n' | cut -c1-27) ...''"         
+              commit="$(echo "''$commit" | tr -d '\n' \t | cut -c1-27) ...''"         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -273,7 +273,6 @@ runs:
             # Check if the commit message is empty.
             if [ -z "$commit" ]; then
               # If it's empty, set a default message based on the triggering event.
-              commit="Triggered by ${{ github.event_name }}."
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
               commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,7 @@ runs:
           echo "unit_test=x" >> $RUNNER_TEMP/icons.properties
 
 
-          if [ "${{ github.event_name }}" == "push" ]; then
+          if [ "${{ github.event_name }}" == "push" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "blackduck_scan=x" >> $RUNNER_TEMP/icons.properties
             echo "create_tag=x" >> $RUNNER_TEMP/icons.properties
           fi
@@ -232,7 +232,7 @@ runs:
         fi
              
         echo "Blackduck icon '${{ steps.all_icons.outputs.blackduck_scan }}'"
-        if [ "${{ github.event_name }}" == "push" ]; then
+        if [ "${{ github.event_name }}" == "push" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
           if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
             blackduck_result="${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components"
             echo "| [Blackduck Scan]($blackduck_result) | :${{ steps.all_icons.outputs.blackduck_scan }}: |" >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -274,6 +274,7 @@ runs:
             if [ -z "$commit" ]; then
               # If it's empty, set a default message based on the triggering event.
               commit="Triggered by ${{ github.event_name }}."
+              commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
               commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
             fi

--- a/action.yaml
+++ b/action.yaml
@@ -273,7 +273,7 @@ runs:
             # Check if the commit message is empty.
             if [ -z "$commit" ]; then
               # If it's empty, set a default message based on the triggering event.
-              commit="\"Workflow was triggered by ${{ github.event_name }} event.\""
+              commit="Triggered by ${{ github.event_name }}."
             else
               commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
             fi

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr '\t\n' ' ' | cut -c1-27) ...''"         
+              commit="$(echo "''$commit" | sed '/^\s*$/d' | tr '\n' '\t' | cut -c1-27) ...''"         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -231,7 +231,7 @@ runs:
             echo "| Sonar Scan | :${{ steps.all_icons.outputs.sonar_scan }}: |" >> $GITHUB_STEP_SUMMARY
         fi
 
-        if [ "${{ github.event_name }}" == "push" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+        if [ "${{ github.event_name }}" == "push" ]; then
           if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
             blackduck_result="${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components"
             echo "| [Blackduck Scan]($blackduck_result) | :${{ steps.all_icons.outputs.blackduck_scan }}: |" >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -273,7 +273,7 @@ runs:
             # Check if the commit message is empty.
             if [ -z "$commit" ]; then
               # If it's empty, set a default message based on the triggering event.
-              commit="Workflow was triggered by ${{ github.event_name }} event."
+              commit="Triggered by ${{ github.event_name }}."
             else
               commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
             fi

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,8 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "$commit" | tr -d '\n' | cut -c1-27) ...\"\""         
+              commit="$(echo "$commit" | tr -d '\n' | cut -c1-27 ) ...''"
+              commit="\"$commit\""        
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -265,6 +265,7 @@ runs:
         branch="${GITHUB_REF#refs/heads/}"
         if [ "${{ github.event_name }}" == "push" ]  || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             if [ -z "${{ github.event.head_commit.url }}" ]; then
+              # If ${{ github.event.head_commit.url }} empty, set a default value.
               details="Details"
             else
               details="<${{ github.event.head_commit.url }}| Details>"
@@ -277,7 +278,7 @@ runs:
             else
               commit="$(echo "$commit" | tr -d '\n' | cut -c1-27) ...''"          
             fi
-            
+
             blackduck_result="Blackduck"
             if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
               blackduck_result="<${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components|${blackduck_result}>"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | sed '/^\s*$/d' | tr '\n' '\t' | cut -c1-27) ...''"         
+              commit="$(echo "''$commit" | tr -d '\n' | cut -c1-27) ...''"      
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr '\n' ' ' | cut -c1-27) ...''"         
+              commit="$(echo "''$commit" | tr '\t\n' ' ' | cut -c1-27) ...''"         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -273,7 +273,7 @@ runs:
             # Check if the commit message is empty.
             if [ -z "$commit" ]; then
               # If it's empty, set a default message based on the triggering event.
-              commit="Triggered by ${{ github.event_name }}."
+              commit=""Triggered by ${{ github.event_name }}.""
             else
               commit="$(echo "''${{ github.event.head_commit.message }}" | cut -c1-27) ...''"
             fi

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr '\n' '\t' | cut -c1-27)...''"         
+              commit="$(echo "''$commit" | tr '\n' '' | cut -c1-27) ...''"         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,8 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit=$(echo "$commit" | tr -s ' ' | sed 's/^ *//' | sed 's/ *$//')
-              commit="$(echo "''$commit" | tr -d '\n' | cut -c1-27) ...''"          
+              commit="$(echo "''$commit" | tr -d '\n' | awk '{$1=$1};1'| cut -c1-27) ...''"          
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr -d '\n' | awk '{$1=$1};1'| cut -c1-27) ...''"          
+              commit="$(echo "''$commit" | tr -d '\n' | awk '{$1=$1};1' | cut -c1-27) ...''"          
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr -d '\n' | awk '{$1=$1};1' | cut -c1-27) ...''"          
+              commit="$(echo "$commit" | tr -d '\n' | cut -c1-27) ...\"\""         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else           
               commit=$(echo "$commit" | tr -d '\n')
-              commit="$(echo "''$commit}" | cut -c1-27) ...''" 
+              commit="$(echo "''$commit" | cut -c1-27) ...''" 
             fi
             blackduck_result="Blackduck"
             if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then

--- a/action.yaml
+++ b/action.yaml
@@ -231,7 +231,7 @@ runs:
             echo "| Sonar Scan | :${{ steps.all_icons.outputs.sonar_scan }}: |" >> $GITHUB_STEP_SUMMARY
         fi
 
-        if [ "${{ github.event_name }}" == "push" ]; then
+        if [ "${{ github.event_name }}" == "push" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
           if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
             blackduck_result="${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components"
             echo "| [Blackduck Scan]($blackduck_result) | :${{ steps.all_icons.outputs.blackduck_scan }}: |" >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -276,8 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "$commit" | tr -d '\n' | cut -c1-27 ) ...''"
-              commit="\"$commit\""        
+              commit="$(echo "''$commit" | tr -d '\n' | cut -c1-27) ...''"         
             fi
 
             blackduck_result="Blackduck"

--- a/action.yaml
+++ b/action.yaml
@@ -276,7 +276,7 @@ runs:
               # If it's empty, set a default message based on the triggering event.
               commit="$(echo "''Triggered by ${{ github.event_name }}")''"
             else
-              commit="$(echo "''$commit" | tr -d '\n' \t | cut -c1-27) ...''"         
+              commit="$(echo "''$commit" | tr -s '\n' '\t' | cut -c1-27) ...''"         
             fi
 
             blackduck_result="Blackduck"


### PR DESCRIPTION
"I have updated the Slack notifications and summary part for the workflow dispatch event. There were some bugs in the previous pull request https://github.com/lumada-common-services/gh-composite-actions/pull/87, including repetitive code and an incorrect commit message, which have now been resolved."