### PR TITLE
[YKN-450] : When manually dispatched, the sonar summary link is incorrect

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -222,7 +222,7 @@ runs:
         if [ "${{ env.SONAR_HOST_URL }}" != "" ] && [ "${{ env.SONAR_PROJECT_KEY }}" != "" ]  && [ "${{ steps.all_icons.outputs.sonar_scan }}" != "x" ]; then
             if [ "${{ github.event_name }}" == "pull_request" ]; then
               sonar_result+="pullRequest=${{ github.event.pull_request.number }}"
-            elif [ "${{ github.event_name }}" == "push" ]; then
+            else
               sonar_result+="branch=${GITHUB_REF#refs/heads/}"
             fi
             echo "| [Sonar Scan]($sonar_result) | :${{ steps.all_icons.outputs.sonar_scan }}: |" >> $GITHUB_STEP_SUMMARY
@@ -292,9 +292,9 @@ runs:
 
         if [ "${{ env.SONAR_HOST_URL }}" != "" ] && [ "${{ env.SONAR_PROJECT_KEY }}" != "" ]  && [ "${{ steps.all_icons.outputs.sonar_scan }}" != "x" ]; then
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-          sonar_result="<${{ env.SONAR_HOST_URL }}/dashboard?id=${{ env.SONAR_PROJECT_KEY }}&pullRequest=${{ github.event.pull_request.number }}|SonarQube>"
-          elif [ "${{ github.event_name }}" == "push" ]; then
-          sonar_result="<${{ env.SONAR_HOST_URL }}/dashboard?id=${{ env.SONAR_PROJECT_KEY }}&branch=${branch}|SonarQube>"
+            sonar_result="<${{ env.SONAR_HOST_URL }}/dashboard?id=${{ env.SONAR_PROJECT_KEY }}&pullRequest=${{ github.event.pull_request.number }}|SonarQube>"
+          else
+            sonar_result="<${{ env.SONAR_HOST_URL }}/dashboard?id=${{ env.SONAR_PROJECT_KEY }}&branch=${branch}|SonarQube>"
           fi
         else
           sonar_result="SonarQube"


### PR DESCRIPTION
Fixed the incorrect Sonar link for the GitHub summary and the Slack notification for the manually dispatched event.