### PR TITLE
[HCICD-450 & HCICD-447 & HCICD-452 ] : Display test results in Github actions, Summary link fix for manually dispatched & Summary fix for Pull_request_target

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ eg.,
           JF_WORKING_DIR: ./frontend
 ```
 Note:
+
+1)JF_WORKING_DIR: we need to explicitly mention the WORK DIR for the scan as mentioned above or else it will scan the entire root directory.
+
+2)When using Frogbot scan with `changed_modules`, the bootstrap image must have both Python and the PYYAML package installed. And we need to use these env variable `JF_CHANGED_PATHS: "${{ steps.change_detection.outputs.changed_modules }}"` to scan only for changed_modules.
+                                                                                                                            
+                                                                                     
 JF_WORKING_DIR: we need to explicitly mention the WORK DIR for the scan as mentioned above or else it will scan the entire root directory
                                                                                                                             
                                                                                      

--- a/README.md
+++ b/README.md
@@ -22,9 +22,23 @@ List of Composite Actions:
 
 5) OWASP Scan: Please refer the to link how we defined the composite action for [owasp scan](https://hv-eng.atlassian.net/wiki/spaces/LFCP/pages/30577266601/Software+Composition+Analysis+OWASP+dependency+check);
 
-6) Publish Artifacts to Registry: Please refer the to link how we defined the composite action for [Publish Artifacts to Registry](https://hv-eng.atlassian.net/wiki/spaces/LSH/pages/30508254316/Manifest+Defined+Package+Deployment);
-
-7) Tag: Commit the changes available in the workspace and tag the code as per the latest commit id. You have also the possibility of pushing to a tag only, by setting `push_tag_only` to `true`.
+6) Publish Artifacts to Registry: Please refer the to link how we defined the composite action for [Publish Artifacts to Registry](https://hv-eng.atlassian.net/wiki/spaces/LSH/pages/30508254316/Manifest+Defined+Package+Deployment);                                                                                     
+7) Frogbot: It will scan for the vulnerable dependencies and report if any issues in the PR   [Frogbot](https://hv-eng.atlassian.net/wiki/spaces/LFCP/pages/30698047820/Git+Repository+scanning+with+JFRrog+Xray+for+security+vulnerabilities);                                                   
+```
+eg.,
+      - name: FrogBot
+        uses: jfrog/frogbot@v2.8.4
+        env:
+          JF_URL: ${{ secrets.JF_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.JF_ACCESS_TOKEN }}
+          JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JF_WORKING_DIR: ./frontend
+```
+Note:
+JF_WORKING_DIR: we need to explicitly mention the WORK DIR for the scan as mentioned above or else it will scan the entire root directory
+                                                                                                                            
+                                                                                     
+8) Tag: Commit the changes available in the workspace and tag the code as per the latest commit id. You have also the possibility of pushing to a tag only, by setting `push_tag_only` to `true`.
 
 
 Sample code snippet for Calling Composite Actions:

--- a/README.md
+++ b/README.md
@@ -46,15 +46,17 @@ main workflow:
 that correspond to in the composite action:
 
 ```
+# Blackduck section
 - name: Blackduck Scan
   if: ${{ env.BlackDuck_Project_Name }}
+  id: blackduck-scan
   uses: addnab/docker-run-action@v3
   with:
-    image: blackducksoftware/detect:8
-    options:  --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
+    image: docker.repo.orl.eng.hitachivantara.com/blackducksoftware/detect:8
+    options: --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
     run: |
-     java -jar /synopsys-detect.jar \
-      --detect.source.path=/workdir \
+      java -jar /synopsys-detect.jar \
+      --detect.source.path=${{ env.BlackDuck_Source_Path || '/workdir' }} \
       --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \
       --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
       --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \

--- a/action.yaml
+++ b/action.yaml
@@ -295,7 +295,7 @@ runs:
         sonar_result="${{ env.SONAR_HOST_URL }}/dashboard?id=${{ env.SONAR_PROJECT_KEY }}&"
 
         if [ "${{ env.SONAR_HOST_URL }}" != "" ] && [ "${{ env.SONAR_PROJECT_KEY }}" != "" ]  && [ "${{ steps.all_icons.outputs.sonar_scan }}" != "x" ]; then
-            if [ "${{ github.event_name }}" == "pull_request" ]; then
+            if [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "pull_request_target" ]; then
               sonar_result+="pullRequest=${{ github.event.pull_request.number }}"
             else
               sonar_result+="branch=${GITHUB_REF#refs/heads/}"
@@ -305,7 +305,7 @@ runs:
             echo "| Sonar Scan | :${{ steps.all_icons.outputs.sonar_scan }}: |" >> $GITHUB_STEP_SUMMARY
         fi
              
-        if [ "${{ github.event_name }}" != "pull_request" ]; then
+        if [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ github.event_name }}" != "pull_request_target" ]; then
           if [ "${{ steps.all_icons.outputs.blackduck_scan }}" != "x" ]  && [ "${{ env.BLACKDUCK_SERVER_URL }}" != "" ]; then
             blackduck_result="${{ env.BLACKDUCK_SERVER_URL }}/api/projects/${{ env.BLACKDUCK_PROJ_ID }}/versions/${{ env.BLACKDUCK_VERSION_ID }}/components"
             echo "| [Blackduck Scan]($blackduck_result) | :${{ steps.all_icons.outputs.blackduck_scan }}: |" >> $GITHUB_STEP_SUMMARY
@@ -343,7 +343,7 @@ runs:
           unit_test="Unit Test"
         fi
 
-        if [ "${{ github.event_name }}" != "pull_request" ]; then
+        if [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ github.event_name }}" != "pull_request_target" ]; then
             if [ -z "${{ github.event.head_commit.url }}" ]; then
               # If ${{ github.event.head_commit.url }} empty, set a default value.
               details="Details"
@@ -366,14 +366,14 @@ runs:
 
             blackduck_message=":arrow_right: Result  :${{ steps.all_icons.outputs.blackduck_scan }}:"
 
-        elif [ "${{ github.event_name }}" == "pull_request" ]; then
+        elif [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "pull_request_target" ]; then
             details="<${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}| Details>"
 
         fi
 
 
         if [ "${{ env.SONAR_HOST_URL }}" != "" ] && [ "${{ env.SONAR_PROJECT_KEY }}" != "" ]  && [ "${{ steps.all_icons.outputs.sonar_scan }}" != "x" ]; then
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          if [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "pull_request_target" ]; then
             sonar_result="<${{ env.SONAR_HOST_URL }}/dashboard?id=${{ env.SONAR_PROJECT_KEY }}&pullRequest=${{ github.event.pull_request.number }}|SonarQube>"
           else
             sonar_result="<${{ env.SONAR_HOST_URL }}/dashboard?id=${{ env.SONAR_PROJECT_KEY }}&branch=${branch}|SonarQube>"

--- a/action.yaml
+++ b/action.yaml
@@ -171,6 +171,23 @@ runs:
         JF_GIT_TOKEN: ${{ env.JF_GIT_TOKEN }}
         JF_WORKING_DIR: ${{ env.JF_WORKING_DIR }}
 
+    - name: Creating Kind Cluster 
+      id: cluster-creation
+      if: ${{env.KIND_CLUSTER_NAME && env.KIND_CLUSTER_ACTION == 'CREATE' }}
+      run: |
+        docker exec -i kind-container kind create cluster --name ${{ env.KIND_CLUSTER_NAME }} --config /mnt/${{env.CONFIG_FILE_NAME}}                              # Creating kind cluster inside of kind-container where Configuration file is at root level 
+        docker exec -i kind-container kind export kubeconfig --name ${{ env.KIND_CLUSTER_NAME }} --kubeconfig /mnt/kubeconfig                                      # Exporting kubeconfig file to /mnt folder mapped to github workspace
+        docker exec -i kind-container kind get clusters
+        docker network connect kind bootstrap-image                                                                                                                # Connecting Bootstrap image to kind network                        
+        kubectl config set-cluster kind-${{ env.KIND_CLUSTER_NAME }} --server=https://${{ env.KIND_CLUSTER_NAME }}-control-plane:6443 --kubeconfig=./kubeconfig
+      shell: bash
+    
+    - name: Deleting Kind Cluster
+      id: cluster-deletion
+      if: ${{env.KIND_CLUSTER_NAME && env.KIND_CLUSTER_ACTION == 'DELETE' }}
+      run : docker exec -i kind-container kind delete cluster --name ${{ env.KIND_CLUSTER_NAME }} 
+      shell: bash
+
     - name: Read icon properties
       if: ${{ env.report }}
       id: all_icons

--- a/action.yaml
+++ b/action.yaml
@@ -162,6 +162,15 @@ runs:
         WORKSPACE: ${{ env.workspace }}
         BUILD_URL: ${{ env.build_url }}
 
+    - name: FrogBot
+      if: ${{ env.JF_URL }}    
+      uses: jfrog/frogbot@v2.8.8
+      env:
+        JF_URL: ${{ env.JF_URL }}
+        JF_ACCESS_TOKEN: ${{ env.JF_ACCESS_TOKEN }}
+        JF_GIT_TOKEN: ${{ env.JF_GIT_TOKEN }}
+        JF_WORKING_DIR: ${{ env.JF_WORKING_DIR }}
+
     - name: Read icon properties
       if: ${{ env.report }}
       id: all_icons
@@ -274,7 +283,6 @@ runs:
         template="$template{ \"value\": \"${blackduck_message}\", \"short\": true }"
 
         echo "slack-attach-fields=${template}" >> $GITHUB_OUTPUT
-
 
     - name: Slack Notification
       if: ${{ env.report && env.Slack_Channel }}

--- a/action.yaml
+++ b/action.yaml
@@ -162,6 +162,13 @@ runs:
         WORKSPACE: ${{ env.workspace }}
         BUILD_URL: ${{ env.build_url }}
 
+    - name: Create and Update frogbot config file
+      if: ${{ env.JF_CHANGED_PATHS && env.JF_URL }}
+      run: |   
+        python3 ${GITHUB_ACTION_PATH}/frogbot/frogbot.py "${{ env.JF_CHANGED_PATHS }}" "${GITHUB_WORKSPACE}" "${{ github.event.repository.name }}" "${{ github.head_ref }}"  
+        cat .frogbot/frogbot-config.yml
+      shell: bash  
+    
     - name: FrogBot
       if: ${{ env.JF_URL }}    
       uses: jfrog/frogbot@v2.8.8
@@ -170,6 +177,7 @@ runs:
         JF_ACCESS_TOKEN: ${{ env.JF_ACCESS_TOKEN }}
         JF_GIT_TOKEN: ${{ env.JF_GIT_TOKEN }}
         JF_WORKING_DIR: ${{ env.JF_WORKING_DIR }}
+        JF_FAIL: "FALSE"
 
     - name: Creating Kind Cluster 
       id: cluster-creation

--- a/frogbot/frogbot.py
+++ b/frogbot/frogbot.py
@@ -1,0 +1,44 @@
+import os,sys
+import yaml
+
+def create_frogbot_config_file(change_modules_path,root_dir,repo_name,source_branch_name):
+
+    data = [{
+        'params': {
+            'git': {
+                'branches': [source_branch_name],
+                'repoName': repo_name
+            },
+            'scan': {
+                'projects': [
+                    {
+                        'workingDirs': change_modules_path
+                    }
+                ]
+            }
+        }
+    }]
+
+    # Directory
+    directory = ".frogbot"
+    # Path
+    path = os.path.join(root_dir, directory)
+    file_path = os.path.join(path, 'frogbot-config.yml')
+    # Create the folder
+    os.makedirs(path, exist_ok=True)
+    # Write data to YAML file
+    with open(file_path, 'w') as file:
+        yaml.dump(data, file)
+    print(f"YAML file '{file_path}' created successfully!")
+
+def main():
+    path=sys.argv[1]
+    change_modules_path=path.split(', ')
+    root_dir= sys.argv[2]
+    repo_name = sys.argv[3]        
+    source_branch_name = sys.argv[4]  
+    print(root_dir)
+    create_frogbot_config_file(change_modules_path,root_dir,repo_name,source_branch_name)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Updated a unit test report generation step that displays the test results on the Github summary and sends notifications on Slack.
Also, fix issues for incorrect Sonar summary links when manually triggered and wrong summary data when pull_request_target is the event that triggered the workflow.