### PR TITLE
Notifications to Teams & Blackduck Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ List of Composite Actions:
 
 8. Tag: Commit the changes available in the workspace and tag the code as per the latest commit id. You have also the possibility of pushing to a tag only, by setting `push_tag_only` to `true`.
 
+9. Reporting: Aims to send messages to a Microsoft Teams channel and/or a Slack channel to help users keep track of all the defined steps in a workflow, along with additional workflow details. A summary table will also be added to the job's summary after the execution of the job, consisting of the same details.
+
+      ```
+      - name: Reporting
+        if: always()
+        uses: lumada-common-services/gh-composite-actions@develop
+        env:
+          Slack_Token: ${{ secrets.SLACK_TOKEN }}                 # Secret Token for Slack channel
+          Slack_Channel: yukon-test                               # The slack channel to receive notifications. 
+          steps_json: '${{ toJson(steps) }}'
+          teams_Webhook_Url: '${{ secrets.TEAMS_WEBHOOK_URL }}'   #Incoming Webhook URL for Teams channel 
+          report: true
+          
+      ```
 
 Sample code snippet for Calling Composite Actions:
 

--- a/action.yaml
+++ b/action.yaml
@@ -439,3 +439,16 @@ runs:
                 }
               ]
             }
+
+    - name: Teams Notification
+      if: ${{ env.report && env.teams_Webhook_Url  }}
+      uses: hv-actions/teams-notify-action@1.0.0
+      with:
+        steps_json: '${{ env.steps_json }}'
+        teams_Webhook_Url: '${{ env.teams_Webhook_Url }}'
+        sonar_Host_Url: '${{ env.SONAR_HOST_URL }}'
+        sonar_Project_Key: '${{env.SONAR_PROJECT_KEY}}'
+        blackDuck_Server_Url: '${{env.BLACKDUCK_SERVER_URL}}'
+        blackDuck_ProjId: '${{env.BLACKDUCK_PROJ_ID}}'
+        blackDuck_VersionId: '${{env.BLACKDUCK_VERSION_ID}}'
+        unit_test_url: '${{ steps.unit_test_url.outputs.url }}'

--- a/action.yaml
+++ b/action.yaml
@@ -157,6 +157,7 @@ runs:
            --detect.source.path=${{ env.BlackDuck_Source_Path || '/workdir' }} \
            --detect.project.version.name="${{ env.BlackDuck_Project_Version }}" \
            --detect.project.name="${{ env.BlackDuck_Project_Name }}" \
+           --detect.accuracy.required=NONE \
            --blackduck.api.token="${{ env.BlackDuck_Api_Token }}" \
            --blackduck.url="${{ env.BlackDuck_Url }}" \
            --detect.blackduck.signature.scanner.snippet.matching="NONE" ${{ env.ADDITIONAL_ARGS }}


### PR DESCRIPTION
Added Teams Notify action to send messages to a Microsoft Teams channel to help users keep track of all the defined steps in a workflow, along with additional workflow details.
Blackduck Fix adding additional parameter [detect.accuracy.required=NONE]