### PR TITLE
[HNC-467]: Fix Branch Protection Limitations for Release Automation

### DIFF
--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.target_commitish }}
+          token: ${{ secrets.HV_ADMIN_GITHUB_TOKEN}} 
 
       - name: Update release.md file
         uses: stefanzweifel/changelog-updater-action@v1
@@ -28,13 +29,14 @@ jobs:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
           path-to-changelog: ${{ env.file_path_md }}
-
+      
       - name: Commit 
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: EndBug/add-and-commit@v9 
         with:
-          branch: ${{ github.event.release.target_commitish }}
-          commit_message: Updated Release Notes
-          file_pattern: ${{ env.file_path_md }}
+          add: ${{ env.file_path_md }} --force
+          message: "[CI/CD] - :robot: Update release notes."
+          push: true
+          default_author: github_actions    
 
   update_confluence_page:
     runs-on: [k8s]

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,3 +1,19 @@
+## 1.6.0 🐝 - 2023-10-10
+
+### What's Changed
+- The Release Automation Process is designed to streamline the release management workflow for our product. It automates various tasks related to labeling PRs, generating release notes, updating documentation, and notifying relevant stakeholders.. [(Pull Request 109)](https://github.com/lumada-common-services/gh-composite-actions/pull/109)
+
+- Added  Integration test step Documentation to Readme file.. [(Pull Request 101)](https://github.com/lumada-common-services/gh-composite-actions/pull/101)
+
+- Added note about GITHUB_TOKEN parameter in Unit Test step. The unit test step requires the GitHub App installation access token (GITHUB_TOKEN) to be passed in order to function correctly.. [(Pull Request 107)](https://github.com/lumada-common-services/gh-composite-actions/pull/107)
+
+
+#### 🐛 Bug Fixes
+- Hyperlink for the unit test is not generating for the pull request workflow
+. [(Pull Request 110)](https://github.com/lumada-common-services/gh-composite-actions/pull/110)
+
+
+
 ## 1.5.0 🐝 - 2023-09-27
 
 ### What's Changed


### PR DESCRIPTION
Note:- As Release Note Automation Process was stuck due to branch protection for the last release which was `1.6.0`. So `release.md` & confluence page where not updated with the latest release info which is `1.6.0` because of that I have manually added the latest release info in  `release.md` file so it will stay synchronized with the newest release done in future.