### PR TITLE
[fix] : Updated Synopsys Detect  scanner to v9 to support npm 9

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -173,7 +173,7 @@ runs:
       id: blackduck-scan
       uses: addnab/docker-run-action@v3
       with:
-        image: docker.repo.orl.eng.hitachivantara.com/blackducksoftware/detect:8
+        image: docker.repo.orl.eng.hitachivantara.com/blackducksoftware/detect:9
         options: --entrypoint "/bin/bash" -v ${{ github.workspace }}:/workdir
         run: |
           java -jar /synopsys-detect.jar \


### PR DESCRIPTION
Upgraded Synopsys Detect Scanner Version to V9 so it supports npm ` 9.8.1 `  as per the[ release notes](https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/currentreleasenotes.html) of v9.

Note: Did not change the docker.repo.orl.eng.hitachivantara.com repo to the global one, as that will imply major changes in the action structure with the introduction of the need to execute a docker login during her execution.

