### PR TITLE
[HNC-501] - Create stable tag for latest tagged release in gh-composite actions.

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -36,7 +36,7 @@ autolabeler:
       - '/cleanup/i'
 
 change-template: |
-  - $BODY. [(Pull Request $NUMBER)]($URL)
+  - $BODY [(Pull Request $NUMBER)]($URL)
 
 template: |
   #  What's Changed 

--- a/.github/tag.sh
+++ b/.github/tag.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Script to manage a static tag on a specific branch in a Git repository
+# Usage: ./script_name.sh <branch_name> <static_tag_name>
+
+# Branch to checkout (provided as the first command line argument)
+git checkout $1
+git pull
+
+# Tag name which is considered static (provided as the second command line argument)
+stable_tag_name=$2
+
+# Get the latest tag and commit associated with the tag
+latest_commit=$(git rev-list -n 1 $(git describe --tags --abbrev=0))
+echo "Latest commit ID on the given branch: $latest_commit"
+
+# Check if the stable tag exists
+if git rev-parse -q --verify "refs/tags/$stable_tag_name" >/dev/null; then
+    echo "Stable tag found."
+
+    # Get the commit hash for the stable tag
+    stable_tag_commit=$(git rev-list -n 1 $stable_tag_name)
+    echo "Commit associated with the stable tag '$stable_tag_name': $stable_tag_commit"
+
+    # Check if the stable tag is already pointing to the latest commit
+    if [ "$stable_tag_commit" == "$latest_commit" ]; then
+        echo "Stable tag already points to the latest commit. Skipping..."
+        exit 0
+    else
+        echo "Updating the commit associated with the stable tag..."
+        git tag -f $stable_tag_name $latest_commit
+    fi
+else
+    # Create a new static tag
+    echo "Creating a new stable tag '$stable_tag_name'..."
+    git tag $stable_tag_name $latest_commit
+fi
+
+# Push the updated or new tag only
+git push -f origin $stable_tag_name

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,10 +3,10 @@ on:
   push:
     branches: [master]
   # when release is done release.md file is updated by automatic commit github action so to avoid trigger of release-drafter added paths-ignore
-    paths-ignore: ['docs/release.md']
+    paths-ignore: ['docs/release.md','.github/**']
 
   # pull_request event is required only for autolabeler
-  pull_request:
+  pull_request_target:
     branches: [master]
   # Only following types are handled by the action, but one can default to all as well
     types: [opened,edited]

--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -12,8 +12,26 @@ env:
   user_for_confluence: honeycomb@hitachivantara.com              # user for API token of Confluence
   
 jobs:
+  update_stable_tag:
+    runs-on: [k8s]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          token: ${{ secrets.HV_ADMIN_GITHUB_TOKEN}} 
+      
+      - run: chmod +x tag.sh 
+
+      - name: Runing tag update script
+        run: .github/tag.sh "master" "stable"
+        shell: bash
+
   update_release_md:
     runs-on: [k8s]
+    needs: update_stable_tag
     permissions:
       contents: write
     steps:

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@
 
 - Include Citadel step tracking in GitHub summaries, Slack, and Teams. Additionally, based on team discussions, remove the Blackduck step from the merge workflow tracking. [(Pull Request 118)](https://github.com/lumada-common-services/gh-composite-actions/pull/118)   
   
-- Fixed Issue You are not currently on a branch . [(Pull Request 117)](https://github.com/lumada-common-services/gh-composite-actions/pull/117)   
+- Fixed Issue You are not currently on a branch. [(Pull Request 117)](https://github.com/lumada-common-services/gh-composite-actions/pull/117)   
   
 
 ## 1.7.0 🐝 - 2023-10-27
@@ -25,23 +25,22 @@
 
 ### What's Changed
 
-- The Release Automation Process is designed to streamline the release management workflow for our product. It automates various tasks related to labeling PRs, generating release notes, updating documentation, and notifying relevant stakeholders.. [(Pull Request 109)](https://github.com/lumada-common-services/gh-composite-actions/pull/109)   
+- The Release Automation Process is designed to streamline the release management workflow for our product. It automates various tasks related to labeling PRs, generating release notes, updating documentation, and notifying relevant stakeholders. [(Pull Request 109)](https://github.com/lumada-common-services/gh-composite-actions/pull/109)   
   
-- Added  Integration test step Documentation to Readme file.. [(Pull Request 101)](https://github.com/lumada-common-services/gh-composite-actions/pull/101)   
+- Added  Integration test step Documentation to Readme file. [(Pull Request 101)](https://github.com/lumada-common-services/gh-composite-actions/pull/101)   
   
-- Added note about GITHUB_TOKEN parameter in Unit Test step. The unit test step requires the GitHub App installation access token (GITHUB_TOKEN) to be passed in order to function correctly.. [(Pull Request 107)](https://github.com/lumada-common-services/gh-composite-actions/pull/107)   
+- Added note about GITHUB_TOKEN parameter in Unit Test step. The unit test step requires the GitHub App installation access token (GITHUB_TOKEN) to be passed in order to function correctly. [(Pull Request 107)](https://github.com/lumada-common-services/gh-composite-actions/pull/107)   
   
 
 #### 🐛 Bug Fixes
 
-- Hyperlink for the unit test is not generating for the pull request workflow   
-  . [(Pull Request 110)](https://github.com/lumada-common-services/gh-composite-actions/pull/110)
+- Hyperlink for the unit test is not generating for the pull request workflow. [(Pull Request 110)](https://github.com/lumada-common-services/gh-composite-actions/pull/110)
 
 ## 1.5.0 🐝 - 2023-09-27
 
 ### What's Changed
 
-- Added Teams Notify action to send messages to a Microsoft Teams channel to help users keep track of all the defined steps in a workflow, along with additional workflow details. Additionally, 'Blackduck Fix' adding an additional parameter `detect.accuracy.required=NONE` . [(Pull Request 104)](https://github.com/lumada-common-services/gh-composite-actions/pull/104)
+- Added Teams Notify action to send messages to a Microsoft Teams channel to help users keep track of all the defined steps in a workflow, along with additional workflow details. Additionally, 'Blackduck Fix' adding an additional parameter `detect.accuracy.required=NONE`. [(Pull Request 104)](https://github.com/lumada-common-services/gh-composite-actions/pull/104)
 
 ## 1.4.1 🐝 - 2023-08-29
 
@@ -66,8 +65,7 @@
 
 ### What's Changed
 
-- Add kind integration code to gh-composite-action   
-  . [(Pull Request 82)](https://github.com/lumada-common-services/gh-composite-actions/pull/82)
+- Add kind integration code to gh-composite-action. [(Pull Request 82)](https://github.com/lumada-common-services/gh-composite-actions/pull/82)
 
 ## 1.0.1 🐝 - 2023-03-16
 


### PR DESCRIPTION

useful links:-

When a stable tag already exists then it updates the commit associated with the stable tag to the latest commit [link](https://github.com/lumada-common-services/lds-composite-action/actions/runs/6941822831/job/18883448250#step:6:152).
When a stable tag doesn't exist then creates new one with latest commit associated to stable tag [link](https://github.com/lumada-common-services/lds-composite-action/actions/runs/6942319979/job/18885028030#step:6:153) 