### PR TITLE
[HNC-510] : Implement INTEGRATION_TEST command type in the composite action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,7 @@ runs:
           echo "sonar_scan=x" >> $RUNNER_TEMP/icons.properties
           echo "build=x" >> $RUNNER_TEMP/icons.properties
           echo "unit_test=x" >> $RUNNER_TEMP/icons.properties
+          echo "integration_test=x" >> $RUNNER_TEMP/icons.properties
 
 
           if [ "${{ github.event_name }}" != "pull_request" ]; then
@@ -46,6 +47,11 @@ runs:
           [[ "${{ steps.run-command.outcome }}" == "success" ]] && icon="white_check_mark"
           sed -i "s/unit_test=x/unit_test=${icon}/g" $RUNNER_TEMP/icons.properties
 
+        elif [ "${{ env.cmd_type }}" == "INTEGRATION_TEST" ]; then
+
+          [[ "${{ steps.run-command.outcome }}" == "success" ]] && icon="white_check_mark"
+          sed -i "s/integration_test=x/integration_test=${icon}/g" $RUNNER_TEMP/icons.properties
+
         elif [ "${{ env.cmd_type }}" == "" ]; then
 
           [[ "${{ steps.run-command.outcome }}" == "success" ]] && icon="white_check_mark"
@@ -55,21 +61,21 @@ runs:
         fi
 
     - name: Check test_report_path exists or not. Additionally, verify if the required parameters have been passed to generate the unit test report.
-      if: ${{ env.cmd_type == 'UNIT_TEST' }}   
+      if: ${{ env.cmd_type == 'UNIT_TEST' || env.cmd_type == 'INTEGRATION_TEST' }}   
       run: |
         test_report_path="${{ env.test_report_path}}"
         reporter="${{ env.reporter}}"
         if [ -z "$test_report_path" ] && [ -z "$reporter" ]; then
-          echo "::warning::Test report will not be generated as both test_report_path and reporter values are empty!"    
+          echo "::warning::Test report will not be generated for ${{ env.cmd_type }}, as both test_report_path and reporter values are empty!"    
         elif [ -z "$test_report_path" ]; then
-          echo "::warning::Empty value passed for test_report_path. Test report will not be generated!"
+          echo "::warning::Empty value passed for test_report_path. Test report will not be generated for ${{ env.cmd_type }}!"
         elif [ -z "$reporter" ]; then
-          echo "::warning::Empty value passed for reporter. Test report will not be generated!"
+          echo "::warning::Empty value passed for reporter. Test report will not be generated for ${{ env.cmd_type }}!"
         else
           if find . -type f -path "$test_report_path" -print -quit | grep -q .; then
             echo -e "\e[32mSuccess\e[0m: Test report files found"
           else
-            echo "::error::No test report files were found. The 'test_report_path' may be incorrect"
+            echo "::error::No test report files were found. The 'test_report_path' may be incorrect for ${{ env.cmd_type }}"
           fi
         fi
 
@@ -78,18 +84,18 @@ runs:
     - name: Test Report
       uses: dorny/test-reporter@v1
       id : test-result
-      if: ${{ env.cmd_type == 'UNIT_TEST' &&  env.test_report_path !='' && env.reporter !='' }}                   
+      if: ${{ (env.cmd_type == 'UNIT_TEST' || env.cmd_type == 'INTEGRATION_TEST') &&  env.test_report_path !='' && env.reporter !='' }}                   
       with:
-        name: ${{ github.job }}-Unit Test                          
+        name: ${{ github.job }}-${{ env.cmd_type }}                          
         path: ${{ env.test_report_path}}              # '**/target/**/*.xml'   
         reporter: ${{ env.reporter }}                 # Format of test results. 
         only-summary: 'true' 
         fail-on-error: ${{ env.fail-on-error || false }}     # Set action as failed if test report contains any failed test
         fail-on-empty: ${{ env.fail-on-empty || false }}     # Set action as failed if no test report files were found
     
-    - name: Check if UNIT_TEST commands were successfully executed 
-      if: ${{ !cancelled() && env.cmd_type == 'UNIT_TEST' }}
-      id: unit_test_exceution
+    - name: Check if UNIT_TEST/INTEGRATION_TEST commands were successfully executed 
+      if: ${{ !cancelled() && (env.cmd_type == 'UNIT_TEST' || env.cmd_type == 'INTEGRATION_TEST') }}
+      id: test_commands_execution
       run: |
         exec=$(cat $RUNNER_TEMP/icons.properties)
         for exe in $exec
@@ -98,17 +104,21 @@ runs:
         done
       shell: bash
 
-    - name: Marking UNIT_TEST Step as failed if there are test failures
-      if: ${{ !cancelled() && env.cmd_type == 'UNIT_TEST' }}
+    - name: Marking UNIT_TEST/INTEGRATION_TEST Step as failed if there are test failures
+      if: ${{ !cancelled() && (env.cmd_type == 'UNIT_TEST' || env.cmd_type == 'INTEGRATION_TEST') }}
       run: |
         icon="boom"
-        if [ "${{ steps.unit_test_exceution.outputs.unit_test }}" == "white_check_mark" ] && [ "${{ steps.test-result.outputs.conclusion }}" == "failure" ] && [ "${{ steps.test-result.outputs.url_html }}" != "" ]; then
+        if [ "${{ env.cmd_type }}" == "UNIT_TEST" ] && [ "${{ steps.test_commands_execution.outputs.unit_test }}" == "white_check_mark" ] && [ "${{ steps.test-result.outputs.conclusion }}" == "failure" ] && [ "${{ steps.test-result.outputs.url_html }}" != "" ]; then
           sed -i "s/unit_test=white_check_mark/unit_test=${icon}/g" $RUNNER_TEMP/icons.properties
-        fi    
+        fi
+        if [ "${{ env.cmd_type }}" == "INTEGRATION_TEST" ] && [ "${{ steps.test_commands_execution.outputs.integration_test }}" == "white_check_mark" ] && [ "${{ steps.test-result.outputs.conclusion }}" == "failure" ] && [ "${{ steps.test-result.outputs.url_html }}" != "" ]; then
+          sed -i "s/integration_test=white_check_mark/integration_test=${icon}/g" $RUNNER_TEMP/icons.properties
+        fi     
       shell: bash
 
+
     - name: Copy test report to target folder
-      if: ${{ always() && env.copy-to-target-path !='' && env.cmd_type == 'UNIT_TEST' }}
+      if: ${{ always() && env.copy-to-target-path !='' && (env.cmd_type == 'UNIT_TEST' || env.cmd_type == 'INTEGRATION_TEST') }}
       run: |
         # checking destination folder exist or not.
         if [ ! -d "${{env.copy-to-target-path}}" ]; then
@@ -119,20 +129,27 @@ runs:
         fi
       shell: bash
 
-
-    - name: Fetch Unit Test Report Url 
-      if: ${{ always() && env.cmd_type == 'UNIT_TEST' }}
-      id: unit-test-report
+    - name: Fetch Test Report Url for Unit Test and Integration step
+      if: ${{ always() && (env.cmd_type == 'UNIT_TEST' || env.cmd_type == 'INTEGRATION_TEST') }}
+      id: test-report
       run: |                  
         REPORT_LINK="${{ steps.test-result.outputs.url_html }}"
         if [ -z "$REPORT_LINK" ]; then
-          echo "::error::Unit Test Report is not Generated"
+          echo "::error::Test Report is not Generated"
         else
-          echo -e "\e[32msuccess\e[0m Unit Test Report Generated: $REPORT_LINK"
+          echo -e "\e[32msuccess\e[0m Test Report Generated: $REPORT_LINK"
         fi
-        # Passing report url to "$RUNNER_TEMP/links.txt" file
-        echo "url=$REPORT_LINK" > $RUNNER_TEMP/links.txt
-      shell: bash    
+        # Determine the appropriate file based on cmd_type
+        FILE_PATH="$RUNNER_TEMP/"
+        if [ "${{ env.cmd_type }}" == "UNIT_TEST" ]; then
+          FILE_PATH+="unit_test_links.txt"
+        elif [ "${{ env.cmd_type }}" == "INTEGRATION_TEST" ]; then
+          FILE_PATH+="integration_test_links.txt"
+        fi
+        # Passing report url to the determined file
+        echo "url=$REPORT_LINK" > $FILE_PATH
+      shell: bash
+
 
       # Sonar section
     - name: Sonar Scan
@@ -213,20 +230,20 @@ runs:
 
     #     sed -i "s/blackduck_scan=x/blackduck_scan=${icon}/g" $RUNNER_TEMP/icons.properties
 
-    - name: OWASP Scan
-      if: ${{ env.owasp_Project }}
-      uses: dependency-check/Dependency-Check_Action@main
-      id: owasp
-      with:
-        project: ${{ env.owasp_Project }}
-        path: '.'
-        format: 'ALL'
-        out: 'reports'
-        args: >
-          --disableNodeJS \
-          --disableAssembly \
-          --disableYarnAudit \
-          --enableRetired
+    # - name: OWASP Scan
+    #   if: ${{ env.owasp_Project }}
+    #   uses: dependency-check/Dependency-Check_Action@main
+    #   id: owasp
+    #   with:
+    #     project: ${{ env.owasp_Project }}
+    #     path: '.'
+    #     format: 'ALL'
+    #     out: 'reports'
+    #     args: >
+    #       --disableNodeJS \
+    #       --disableAssembly \
+    #       --disableYarnAudit \
+    #       --enableRetired
 
     # Tagging
     - name: Prepare tagging
@@ -329,12 +346,24 @@ runs:
       id: unit_test_url
       shell: bash
       run: |
-        if [ -f $RUNNER_TEMP/links.txt ]; then
-          value=$(cat $RUNNER_TEMP/links.txt)
+        if [ -f $RUNNER_TEMP/unit_test_links.txt ]; then
+          value=$(cat $RUNNER_TEMP/unit_test_links.txt)
           echo "$value" >> $GITHUB_OUTPUT
         else
           echo "url=" >> $GITHUB_OUTPUT
-        fi   
+        fi
+
+    - name: Read Inegration test report url
+      if: ${{ env.report }}
+      id: integration_test_url
+      shell: bash
+      run: |
+        if [ -f $RUNNER_TEMP/integration_test_links.txt ]; then
+          value=$(cat $RUNNER_TEMP/integration_test_links.txt)
+          echo "$value" >> $GITHUB_OUTPUT
+        else
+          echo "url=" >> $GITHUB_OUTPUT
+        fi      
            
     - name: Report Summary Tracking
       if: ${{ env.report }}
@@ -349,6 +378,15 @@ runs:
         else
           echo "| Unit Test | :${{ steps.all_icons.outputs.unit_test }}: |" >> $GITHUB_STEP_SUMMARY
         fi
+
+        if [ "${{ steps.all_icons.outputs.integration_test }}" == "boom" ] || [ "${{ steps.all_icons.outputs.integration_test }}" == "white_check_mark" ]; then
+            if [ "${{ steps.integration_test_url.outputs.url }}" != "" ]; then
+                echo "| [Integration Test](${{ steps.integration_test_url.outputs.url }}) | :${{ steps.all_icons.outputs.integration_test }}: |" >> $GITHUB_STEP_SUMMARY
+            else
+                echo "| Integration Test | :${{ steps.all_icons.outputs.integration_test }}: |" >> $GITHUB_STEP_SUMMARY
+            fi
+        fi
+
 
         sonar_result="${{ env.SONAR_HOST_URL }}/dashboard?id=${{ env.SONAR_PROJECT_KEY }}&"
 
@@ -405,6 +443,15 @@ runs:
           unit_test="Unit Test"
         fi
 
+        if [ "${{ steps.all_icons.outputs.integration_test }}" == "boom" ] || [ "${{ steps.all_icons.outputs.integration_test }}" == "white_check_mark" ]; then
+            if [ "${{ steps.integration_test_url.outputs.url }}" != "" ]; then
+              integration_test="<${{ steps.integration_test_url.outputs.url }})|Integration Test>" 
+            else
+              integration_test="Integration Test"
+            fi
+            integration_test_meesage=":arrow_right: Result  :${{ steps.all_icons.outputs.integration_test }}:"
+        fi
+
         if [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ github.event_name }}" != "pull_request_target" ]; then
             if [ -z "${{ github.event.head_commit.url }}" ]; then
               # If ${{ github.event.head_commit.url }} empty, set a default value.
@@ -456,10 +503,19 @@ runs:
         template="$template{ \"value\": \"${commit}\", \"short\": true },"
         template="$template{ \"value\": \":arrow_right: Result  :${{ steps.all_icons.outputs.unit_test }}:\n\", \"short\": true },"
         template="$template{ \"value\": \" \", \"short\": true },"
+         
+        if [ "${{ steps.all_icons.outputs.integration_test }}" == "boom" ] || [ "${{ steps.all_icons.outputs.integration_test }}" == "white_check_mark" ]; then
+          template="$template{ \"value\": \"$integration_test\", \"short\": true },"
+          template="$template{ \"value\": \" \", \"short\": true },"
+          template="$template{ \"value\": \"${integration_test_meesage}\", \"short\": true },"
+          template="$template{ \"value\": \" \", \"short\": true },"
+        fi
+
         template="$template{ \"value\": \"$sonar_result\", \"short\": true },"
         template="$template{ \"value\": \" \", \"short\": true },"
         template="$template{ \"value\": \":arrow_right: Result  :${{ steps.all_icons.outputs.sonar_scan }}:\", \"short\": true },"
         template="$template{ \"value\": \" \", \"short\": true },"
+        
         template="$template{ \"value\": \"${citadel_result}\", \"short\": true },"
         template="$template{ \"value\": \" \", \"short\": true },"
         template="$template{ \"value\": \"${citadel_message}\", \"short\": true }"


### PR DESCRIPTION
Added the `INTEGRATION_TEST` command type to the composite action for tracking in the reporting step. This integration step will only be tracked if it is run

Test cases:

- [first fail(fail-on-error: false) and second fail](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031181499)
- [Unit fail(error: false) & Int fail(error:false)](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031225104)
- [Unit fail(error: false) & Int pass(error:false)](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031256117)
- [Unit fail(error: false) & Int pass(error:true)](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031367147)
- [Unit fail(error: false) & Int fail(error:true)](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031395156)
- [Unit pass(error: true) & Int fail(error:true)](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031450158)
- [Unit pass(error: true) & Int fail(error:false)](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031480144)
- [Unit pass(error: true) & Int pass(error:true)](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031505523)
- [Unit pass(error: true), empty value for int](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031614714)
- [Empty value for Unit Test step](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031648352)
- [Empty value passed for both](https://github.com/lumada-common-services/honeycomb-samples/actions/runs/7031742286)