### PR TITLE
[fix] HNC-564 - Update hv-actions/slack-action to use stable tag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -752,7 +752,7 @@ runs:
 
     - name: Slack Notification
       if: ${{ env.report && env.Slack_Channel }}
-      uses: hv-actions/slack-action@v3
+      uses: hv-actions/slack-action@stable
       env:
         SLACK_TOKEN: ${{ env.Slack_Token }}
       with:


### PR DESCRIPTION
Updated hv-actions/slack-action to use `stable` tag.