### PR TITLE
ci: send only the commit title

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -647,7 +647,7 @@ runs:
             else
               details="<${{ github.event.head_commit.url }}| Details>"
             fi
-            commit="${{ github.event.head_commit.message }}"
+            commit="$(printf '%s' "${{ github.event.head_commit.message }}" | head -n 1)"
             # Check if the commit message is empty.
             if [ -z "$commit" ]; then
               # If it's empty, set a default message based on the triggering event.


### PR DESCRIPTION
This pull request makes a small update to how commit messages are handled in the `action.yaml` file. The change ensures that only the first line of the commit message is used, which helps keep commit summaries concise and avoids including multi-line commit messages in contexts where only a summary is needed.